### PR TITLE
Handle error when indexing string in an unsupported language

### DIFF
--- a/arches_search/indexing/indexers/string.py
+++ b/arches_search/indexing/indexers/string.py
@@ -3,8 +3,8 @@ from django.contrib.postgres.search import SearchVector
 from arches.app.datatypes.datatypes import DataTypeFactory
 from arches.app.models.models import Language
 from arches_search.models.models import TermSearch
-
 from arches_search.indexing.base import BaseIndexing
+import sys
 
 
 class StringIndexing(BaseIndexing):
@@ -37,4 +37,10 @@ class StringIndexing(BaseIndexing):
                 Value(string_object["string"]),
                 config=self.languages[string_object["language"]].name.lower(),
             )
-            term_search.save()
+            try:
+                term_search.save()
+            except Exception as e:
+                sys.stdout.write(
+                    f"Unable to index: value '{term_search.value}' in language '{term_search.language}' on node '{term_search.node_alias}' in tile '{term_search.tileid}' due to the following error:"
+                )
+                sys.stdout.write(str(e))


### PR DESCRIPTION
Handles error in cases where a string is being indexed in a language unsupported by full text search. We will need to document unsupported languages and provide information on how to load dictionaries for them (Hebrew for example has an established dictionary https://github.com/IgKh/pg_hspell). Other dictionaries are available here https://github.com/JetBrains/hunspell-dictionaries/tree/master, although maybe it's possible to find more recent versions.

There's an example on [this github page](https://wassimbj.github.io/blog/full-text-search-in-postgres) showing how to load a language dictionary from https://github.com/JetBrains/hunspell-dictionaries/tree/master 