### PR TITLE
Add missing URL declaration for modular reports #169

### DIFF
--- a/arches_search/urls.py
+++ b/arches_search/urls.py
@@ -135,6 +135,7 @@ handler500 = "arches.app.views.main.custom_500"
 urlpatterns.append(path("", include("arches_controlled_lists.urls")))
 urlpatterns.append(path("", include("arches_component_lab.urls")))
 urlpatterns.append(path("", include("arches_querysets.urls")))
+urlpatterns.append(path("", include("arches_modular_reports.urls")))
 
 urlpatterns.append(path("", include("arches.urls")))
 


### PR DESCRIPTION
fixes #169 

Adds missing urls declaration for arches-modular-reports