### PR TITLE
fixes default ordering bug

### DIFF
--- a/arches_search/utils/search_aggregation.py
+++ b/arches_search/utils/search_aggregation.py
@@ -270,8 +270,10 @@ def build_aggregations(
         # Apply metric annotations and group-by fields
         if metric_annotations:
             group_fields = [g["alias"] for g in group_bys]
-            local_queryset = local_queryset.values(*group_fields).annotate(
-                **metric_annotations
+            local_queryset = (
+                local_queryset.order_by()
+                .values(*group_fields)
+                .annotate(**metric_annotations)
             )
 
         if where_clause:


### PR DESCRIPTION
This is a well-known Django ORM gotcha: .values().annotate() aggregation queries are silently broken when the model has a default ordering, because Django folds any unselected ORDER BY columns into the GROUP BY. Clearing the ordering first keeps the GROUP BY to exactly the columns specified.

This may have come up after sorting was added to the advanced search api (https://github.com/archesproject/arches-search/commit/704cc4341b60daf68f19abb08e42014d11cb355e)